### PR TITLE
feat: implement advanced customer search with pagination and seeder f…

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -58,13 +58,48 @@ class AuthController extends Controller
             return response()->json(['message' => 'No autorizado'], 401);
         }
 
-        // Listado de clientes (ejemplo)
-        $clientes = DB::table('SalesLT.Customer')
-            ->select('CustomerID', 'FirstName', 'LastName', 'EmailAddress')
-            ->orderBy('CustomerID')
-            ->take(20)
-            ->get();
+        // Build query joining customers with customer_addresses
+        $qb = DB::table('customers')
+            ->leftJoin('customer_addresses', 'customers.id', '=', 'customer_addresses.customer_id')
+            ->select('customers.id as id', 'customers.first_name', 'customers.last_name', 'customers.email')
+            ->distinct()
+            ->orderBy('customers.id');
 
-        return response()->json($clientes, 200);
+        if ($request->filled('city')) {
+            $qb->where('customer_addresses.city', $request->query('city'));
+        }
+
+        if ($request->filled('state')) {
+            $qb->where('customer_addresses.state', $request->query('state'));
+        }
+
+        $page = max(1, (int) $request->query('page', 1));
+        $limit = max(1, (int) $request->query('limit', 10));
+        $offset = ($page - 1) * $limit;
+
+        // total distinct customers matching filters
+        $totalQ = DB::table('customers')
+            ->leftJoin('customer_addresses', 'customers.id', '=', 'customer_addresses.customer_id');
+
+        if ($request->filled('city')) {
+            $totalQ->where('customer_addresses.city', $request->query('city'));
+        }
+
+        if ($request->filled('state')) {
+            $totalQ->where('customer_addresses.state', $request->query('state'));
+        }
+
+        $total = $totalQ->distinct()->count('customers.id');
+
+        $clientes = $qb->offset($offset)->limit($limit)->get();
+
+        return response()->json([
+            'data' => $clientes,
+            'meta' => [
+                'page' => $page,
+                'limit' => $limit,
+                'total' => $total,
+            ],
+        ], 200);
     }
 }

--- a/database/seeders/CustomerSeeder.php
+++ b/database/seeders/CustomerSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class CustomerSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    public function run(): void
+    {
+        $now = Carbon::now();
+
+        // Create sample customers
+        $customers = [
+            ['first_name' => 'Ana', 'last_name' => 'Gomez', 'email' => 'ana@example.com', 'created_at' => $now, 'updated_at' => $now],
+            ['first_name' => 'Luis', 'last_name' => 'Martinez', 'email' => 'luis@example.com', 'created_at' => $now, 'updated_at' => $now],
+            ['first_name' => 'Carla', 'last_name' => 'Perez', 'email' => 'carla@example.com', 'created_at' => $now, 'updated_at' => $now],
+            ['first_name' => 'Jose', 'last_name' => 'Lopez', 'email' => 'jose@example.com', 'created_at' => $now, 'updated_at' => $now],
+        ];
+
+        $ids = [];
+        foreach ($customers as $c) {
+            $ids[] = DB::table('customers')->insertGetId($c);
+        }
+
+        // Create addresses for customers with different cities/states
+        $addresses = [
+            ['customer_id' => $ids[0], 'line' => 'Calle 1', 'city' => 'Madrid', 'state' => 'Madrid', 'country' => 'ES', 'created_at' => $now, 'updated_at' => $now],
+            ['customer_id' => $ids[1], 'line' => 'Avenida 2', 'city' => 'Barcelona', 'state' => 'Catalonia', 'country' => 'ES', 'created_at' => $now, 'updated_at' => $now],
+            ['customer_id' => $ids[2], 'line' => 'Street 3', 'city' => 'Valencia', 'state' => 'Valencian Community', 'country' => 'ES', 'created_at' => $now, 'updated_at' => $now],
+            // Multiple addresses for one customer (to ensure distinct results)
+            ['customer_id' => $ids[3], 'line' => 'Road 4', 'city' => 'Madrid', 'state' => 'Madrid', 'country' => 'ES', 'created_at' => $now, 'updated_at' => $now],
+            ['customer_id' => $ids[3], 'line' => 'Road 5', 'city' => 'Seville', 'state' => 'Andalusia', 'country' => 'ES', 'created_at' => $now, 'updated_at' => $now],
+        ];
+
+        DB::table('customer_addresses')->insert($addresses);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,7 +22,8 @@ class DatabaseSeeder extends Seeder
             'email' => 'test@example.com',
         ]);
 
-        // Seed sample orders for local testing
+            // Seed sample orders and customers for local testing
+        $this->call(\Database\Seeders\CustomerSeeder::class);
         $this->call(\Database\Seeders\SalesOrderHeaderSeeder::class);
     }
 }


### PR DESCRIPTION
…or sample data


This pull request introduces significant improvements to the customer listing endpoint and enhances the database seeding process for local testing. The main changes include adding filtering and pagination to the customer API, as well as providing a dedicated seeder for customers and their addresses.

**API Enhancements:**

- The `clientes` endpoint in `AuthController` now supports filtering customers by city and state, and includes pagination with metadata (current page, limit, total results). The query was also updated to join `customers` with their addresses and ensure distinct customer results.

**Database Seeding Improvements:**

- Added a new seeder, `CustomerSeeder`, which creates sample customers and related addresses with varying cities and states for more realistic test data.
- Updated the main `DatabaseSeeder` to call the new `CustomerSeeder` so that sample customers and their addresses are seeded along with orders during local development.